### PR TITLE
fix benchmark stopwatch

### DIFF
--- a/gnocchiclient/benchmark.py
+++ b/gnocchiclient/benchmark.py
@@ -68,7 +68,7 @@ class StopWatch(object):
         self.started_at = now()
 
     def elapsed(self):
-        return max(0.0, self.started_at - now())
+        return max(0.0, now() - self.started_at)
 
 
 def measure_job(fn, *args, **kwargs):


### PR DESCRIPTION
we're computing elapsed time wrong. it always gives 0.