### PR TITLE
Show timestamps in local timezone by default

### DIFF
--- a/doc/source/shell.rst
+++ b/doc/source/shell.rst
@@ -56,6 +56,19 @@ For more details, check the `keystoneauth documentation`_.
 .. _`keystoneauth documentation`: https://docs.openstack.org/developer/keystoneauth/
 
 
+Timestamps
+++++++++++
+
+By default, timestamps are displayed in local time zone. If you prefer to see
+timestamps dispalyed in UTC time zones, you can pass the `--utc` option to the
+command.
+
+The `gnocchi` command line interface parses timestamps in the `ISO8601`_
+format. If no time zone is specified, timestamps are assumed to be in the local
+client time zone.
+
+.. _`ISO8601`: https://en.wikipedia.org/wiki/ISO_8601
+
 Commands descriptions
 +++++++++++++++++++++
 

--- a/gnocchiclient/benchmark.py
+++ b/gnocchiclient/benchmark.py
@@ -27,6 +27,7 @@ import iso8601
 from monotonic import monotonic as now  # noqa
 import six.moves
 
+from gnocchiclient import utils
 from gnocchiclient.v1 import metric_cli
 
 
@@ -244,12 +245,12 @@ class CliBenchmarkMeasuresAdd(CliBenchmarkBase,
                             default=(
                                 datetime.datetime.now(tz=iso8601.iso8601.UTC)
                                 - datetime.timedelta(days=365)),
-                            type=iso8601.parse_date,
+                            type=utils.parse_date,
                             help="First timestamp to use")
         parser.add_argument("--timestamp-end", "-e",
                             default=(
                                 datetime.datetime.now(tz=iso8601.iso8601.UTC)),
-                            type=iso8601.parse_date,
+                            type=utils.parse_date,
                             help="Last timestamp to use")
         parser.add_argument("--wait",
                             default=False,

--- a/gnocchiclient/utils.py
+++ b/gnocchiclient/utils.py
@@ -11,7 +11,8 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
+from dateutil import tz
+import iso8601
 import pyparsing as pp
 import six
 from six.moves.urllib import parse as urllib_parse
@@ -223,3 +224,21 @@ def get_client(obj):
         # TODO(sileht): Remove this when OSC is able
         # to install the gnocchi client binary itself
         return obj.app.client
+
+
+LOCAL_TIMEZONE = tz.gettz()
+
+
+def parse_date(s):
+    """Parse date from string.
+
+    If no timezone is specified, default is assumed to be local time zone.
+
+    :param s: The date to parse.
+    :type s: str
+    """
+    return iso8601.parse_date(s, LOCAL_TIMEZONE)
+
+
+def dt_to_localtz(d):
+    return d.astimezone(LOCAL_TIMEZONE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ futurist
 iso8601
 monotonic
 pyparsing>=2.2.0
+python-dateutil


### PR DESCRIPTION
Many users are confused by the fact the returned timezone by the CLI is in UTC
where they expect to have local timezone. This fixes that by default while
keeping a --utc flag so it's possible to have UTC if wanted.