### PR TITLE
Add archive-policy-rule rename subcommmand

### DIFF
--- a/gnocchiclient/shell.py
+++ b/gnocchiclient/shell.py
@@ -61,6 +61,7 @@ class GnocchiCommandManager(commandmanager.CommandManager):
         "archive-policy-rule list": ap_rule_cli.CliArchivePolicyRuleList,
         "archive-policy-rule show": ap_rule_cli.CliArchivePolicyRuleShow,
         "archive-policy-rule create": ap_rule_cli.CliArchivePolicyRuleCreate,
+        "archive-policy-rule rename": ap_rule_cli.CliArchivePolicyRuleRename,
         "archive-policy-rule delete": ap_rule_cli.CliArchivePolicyRuleDelete,
         "metric list": metric_cli.CliMetricList,
         "metric show": metric_cli.CliMetricShow,

--- a/gnocchiclient/tests/functional/test_archive_policy_rule.py
+++ b/gnocchiclient/tests/functional/test_archive_policy_rule.py
@@ -53,6 +53,16 @@ class ArchivePolicyRuleClientTest(base.ClientTestBase):
         for field in ["metric_pattern", "archive_policy_name"]:
             self.assertEqual(policy_rule[field], rule_from_list[field])
 
+        # PATCH
+        result = self.gnocchi(
+            u'archive-policy-rule', params=u"create test-rename"
+            u" --archive-policy-name %s"
+            u" --metric-pattern 'disk.io.*'" % apname)
+        result = self.gnocchi('archive-policy-rule',
+                              params="rename test-rename renamed")
+        policy_rule = self.details_multiple(result)[0]
+        self.assertEqual("renamed", policy_rule["name"])
+
         # DELETE
         result = self.gnocchi('archive-policy-rule',
                               params="delete test")

--- a/gnocchiclient/v1/archive_policy_rule.py
+++ b/gnocchiclient/v1/archive_policy_rule.py
@@ -41,6 +41,20 @@ class ArchivePolicyRuleManager(base.Manager):
             self.url, headers={'Content-Type': "application/json"},
             data=ujson.dumps(archive_policy_rule)).json()
 
+    def rename(self, name, new_name):
+        """Rename archive policy rule
+
+        :param name: Name of the archive policy rule to be renamed
+        :type name: str
+        :param new_name: New name of the archive policy
+        :type new_name: str
+        """
+        body = ujson.dumps({'name': new_name})
+        return self._patch(
+            self.url + name,
+            headers={'Content-Type': "application/json"},
+            data=body).json()
+
     def delete(self, name):
         """Delete an archive policy rule
 

--- a/gnocchiclient/v1/archive_policy_rule_cli.py
+++ b/gnocchiclient/v1/archive_policy_rule_cli.py
@@ -66,6 +66,26 @@ class CliArchivePolicyRuleCreate(show.ShowOne):
         return self.dict2columns(policy)
 
 
+class CliArchivePolicyRuleRename(show.ShowOne):
+    """Rename an archive policy rule"""
+
+    def get_parser(self, prog_name):
+        parser = super(CliArchivePolicyRuleRename, self).get_parser(prog_name)
+        parser.add_argument("name",
+                            help=("Name of the archive policy rule "
+                                  " to be renamed"))
+        parser.add_argument("new_name",
+                            help="New name of the archive policy rule")
+
+        return parser
+
+    def take_action(self, parsed_args):
+        rule = utils.get_client(self).archive_policy_rule.rename(
+            parsed_args.name,
+            parsed_args.new_name)
+        return self.dict2columns(rule)
+
+
 class CliArchivePolicyRuleDelete(command.Command):
     """Delete an archive policy rule"""
 


### PR DESCRIPTION
Following Gnocchi's #382 PR adding an API to rename archive policy rules

Do not merge until the Gnocchi PR is merged first (well, CI will fail anyway).

Here's an excerpt from my local testing
```bash
$ gnocchi archive-policy-rule list                              
+------------------------+---------------------+------------------+
| name                   | archive_policy_name | metric_pattern   |
+------------------------+---------------------+------------------+
| network-interface-rate | rate:low            | interface-*@if_* |
| default                | low                 | *                |
$ gnocchi archive-policy-rule rename network-interface-rate toto
$ gnocchi archive-policy-rule list                              
+---------+---------------------+------------------+
| name    | archive_policy_name | metric_pattern   |
+---------+---------------------+------------------+
| toto    | rate:low            | interface-*@if_* |
| default | low                 | *                |

```