### PR TITLE
Pass explicit kwargs to metric.create

### DIFF
--- a/gnocchiclient/benchmark.py
+++ b/gnocchiclient/benchmark.py
@@ -207,13 +207,15 @@ class CliBenchmarkMetricCreate(CliBenchmarkBase,
                             help="Keep created metrics")
         return parser
 
-    def _take_action(self, metric, parsed_args):
+    def take_action(self, parsed_args):
         pool = BenchmarkPool(parsed_args.workers)
 
         LOG.info("Creating metrics")
-        futures = pool.submit_job(parsed_args.count,
-                                  self.app.client.metric.create,
-                                  metric, refetch_metric=False)
+        futures = pool.submit_job(
+            parsed_args.count,
+            self.app.client.metric._create_new,
+            archive_policy_name=parsed_args.archive_policy_name,
+            resource_id=parsed_args.resource_id)
         created_metrics, runtime, stats = pool.wait_job("create", futures)
 
         if not parsed_args.keep:

--- a/gnocchiclient/tests/functional/test_aggregates.py
+++ b/gnocchiclient/tests/functional/test_aggregates.py
@@ -33,7 +33,7 @@ class AggregatesClientTest(base.ClientTestBase):
         self.assertEqual("admin", metric1["creator"])
         self.assertEqual('metric-name', metric1["name"])
         self.assertIsNone(metric1["unit"])
-        self.assertIsNotNone(metric1["resource/id"])
+        self.assertIsNotNone(metric1["resource_id"])
         self.assertIn("agg-fetch-test", metric1["archive_policy/name"])
 
         # CREATE ANOTHER METRIC
@@ -47,7 +47,7 @@ class AggregatesClientTest(base.ClientTestBase):
         self.assertEqual("admin", metric2["creator"])
         self.assertEqual('metric-name', metric2["name"])
         self.assertEqual('some-unit', metric2["unit"])
-        self.assertIsNotNone(metric2["resource/id"])
+        self.assertIsNotNone(metric2["resource_id"])
         self.assertIn("agg-fetch-test", metric2["archive_policy/name"])
 
         # MEASURES ADD

--- a/gnocchiclient/v1/metric_cli.py
+++ b/gnocchiclient/v1/metric_cli.py
@@ -107,12 +107,6 @@ class CliMetricCreateBase(show.ShowOne, CliMetricWithResourceID):
                             help="name of the archive policy")
         return parser
 
-    def take_action(self, parsed_args):
-        metric = utils.dict_from_parsed_args(parsed_args,
-                                             ["archive_policy_name",
-                                              "resource_id"])
-        return self._take_action(metric, parsed_args)
-
 
 class CliMetricCreate(CliMetricCreateBase):
     """Create a metric"""
@@ -126,15 +120,17 @@ class CliMetricCreate(CliMetricCreateBase):
                             help="unit of the metric")
         return parser
 
-    def _take_action(self, metric, parsed_args):
-        if parsed_args.name:
-            metric['name'] = parsed_args.name
-        if parsed_args.unit:
-            metric['unit'] = parsed_args.unit
-        metric = utils.get_client(self).metric.create(metric)
+    def take_action(self, parsed_args):
+        metric = utils.get_client(self).metric._create_new(
+            archive_policy_name=parsed_args.archive_policy_name,
+            name=parsed_args.name,
+            resource_id=parsed_args.resource_id,
+            unit=parsed_args.unit,
+        )
         utils.format_resource_for_metric(metric)
-        metric['archive_policy/name'] = metric["archive_policy"]["name"]
-        del metric['archive_policy']
+        if 'archive_policy' in metric:
+            metric['archive_policy/name'] = metric["archive_policy"]["name"]
+            del metric['archive_policy']
         del metric['created_by_user_id']
         del metric['created_by_project_id']
         return self.dict2columns(metric)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ futurist
 iso8601
 monotonic
 python-dateutil
+debtcollector


### PR DESCRIPTION
Passing just a dict is not very friendly as a Python API.
Expose correctly what Gnocchi expects on the other side.