### PR TITLE
Fix osc client

### DIFF
--- a/gnocchiclient/auth.py
+++ b/gnocchiclient/auth.py
@@ -45,6 +45,9 @@ class GnocchiNoAuthPlugin(plugin.BaseAuthPlugin):
     def get_endpoint(self, session, **kwargs):
         return self._endpoint
 
+    def get_auth_ref(self, session, **kwargs):
+        return None
+
 
 class GnocchiOpt(loading.Opt):
     @property
@@ -98,6 +101,9 @@ class GnocchiBasicPlugin(plugin.BaseAuthPlugin):
 
     def get_endpoint(self, session, **kwargs):
         return self._endpoint
+
+    def get_auth_ref(self, session, **kwargs):
+        return None
 
 
 class GnocchiBasicLoader(loading.BaseLoader):

--- a/gnocchiclient/osc.py
+++ b/gnocchiclient/osc.py
@@ -38,8 +38,10 @@ def make_client(instance):
     # NOTE(sileht): ensure setup of the session is done
     instance.setup_auth()
     return gnocchi_client(session=instance.session,
-                          interface=instance.interface,
-                          region_name=instance.region_name)
+                          adapter_options={
+                              'interface': instance.interface,
+                              'region_name': instance.region_name
+                          })
 
 
 def build_option_parser(parser):

--- a/gnocchiclient/tests/functional/base.py
+++ b/gnocchiclient/tests/functional/base.py
@@ -31,6 +31,16 @@ class ClientTestBase(testtools.TestCase):
         self.cli_dir = os.environ.get('GNOCCHI_CLIENT_EXEC_DIR')
         self.endpoint = os.environ.get('PIFPAF_GNOCCHI_HTTP_URL')
 
+    def openstack(self, action, flags='', params='',
+                  fail_ok=False, merge_stderr=False, input=None,
+                  has_output=True):
+        flags = ((("--os-auth-type gnocchi-basic "
+                   "--os-user admin "
+                   "--os-endpoint %s") % self.endpoint)
+                 + ' ' + flags)
+        return self._run("openstack", action, flags, params, fail_ok,
+                         merge_stderr, input, has_output)
+
     def gnocchi(self, action, flags='', params='',
                 fail_ok=False, merge_stderr=False, input=None,
                 has_output=True):
@@ -38,10 +48,16 @@ class ClientTestBase(testtools.TestCase):
                    "--user admin "
                    "--endpoint %s") % self.endpoint)
                  + ' ' + flags)
+        return self._run("gnocchi", action, flags, params, fail_ok,
+                         merge_stderr, input, has_output)
+
+    def _run(self, binary, action, flags='', params='',
+             fail_ok=False, merge_stderr=False, input=None,
+             has_output=True):
 
         fmt = '-f json' if has_output and action != 'help' else ""
 
-        cmd = ' '.join([os.path.join(self.cli_dir, "gnocchi"),
+        cmd = ' '.join([os.path.join(self.cli_dir, binary),
                         flags, action, params, fmt])
         if six.PY2:
             cmd = cmd.encode('utf-8')

--- a/gnocchiclient/tests/functional/test_osc.py
+++ b/gnocchiclient/tests/functional/test_osc.py
@@ -1,0 +1,25 @@
+# -*- encoding: utf-8 -*-
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import json
+
+from gnocchiclient.tests.functional import base
+
+
+class OpenstackClentPluginTest(base.ClientTestBase):
+
+    def test_osc_client(self):
+        result = self.openstack("metric status")
+        status = json.loads(result)
+        self.assertEqual(2, len(status))

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,6 +83,7 @@ test =
   testrepository>=0.0.18
   testtools>=1.4.0
   os-testr
+  python-openstackclient
 
 doc =
   sphinx!=1.2.0,!=1.3b1,>=1.1.2


### PR DESCRIPTION
We have no functional test for the OSC client.

This change add one to ensure we can really setup the osc client plugin.

For this, we fix two things:
* the missing get_auth_ref() for our custom keystonauth plugin
  this method need to be implemented for osc client
* replace the deprecated interface/region_name arguments by
  adapter_options equivalent.