### PR TITLE
Fix osc client

### DIFF
--- a/gnocchiclient/auth.py
+++ b/gnocchiclient/auth.py
@@ -45,6 +45,9 @@ class GnocchiNoAuthPlugin(plugin.BaseAuthPlugin):
     def get_endpoint(self, session, **kwargs):
         return self._endpoint
 
+    def get_auth_ref(self, session, **kwargs):
+        return None
+
 
 class GnocchiOpt(loading.Opt):
     @property
@@ -98,6 +101,9 @@ class GnocchiBasicPlugin(plugin.BaseAuthPlugin):
 
     def get_endpoint(self, session, **kwargs):
         return self._endpoint
+
+    def get_auth_ref(self, session, **kwargs):
+        return None
 
 
 class GnocchiBasicLoader(loading.BaseLoader):

--- a/gnocchiclient/osc.py
+++ b/gnocchiclient/osc.py
@@ -38,8 +38,10 @@ def make_client(instance):
     # NOTE(sileht): ensure setup of the session is done
     instance.setup_auth()
     return gnocchi_client(session=instance.session,
-                          interface=instance.interface,
-                          region_name=instance.region_name)
+                          adapter_options={
+                              'interface': instance.interface,
+                              'region_name': instance.region_name
+                          })
 
 
 def build_option_parser(parser):

--- a/gnocchiclient/tests/functional/test_osc.py
+++ b/gnocchiclient/tests/functional/test_osc.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from gnocchiclient.tests.functional import base
+
+
+class OpenstackClentPluginTest(base.ClientTestBase):
+
+    def test_osc_client(self):
+        result = self.openstack("metric status")
+        status = self.details_multiple(result)[0]
+        self.assertEqual(2, len(status))

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,6 +83,7 @@ test =
   tempest>=10
   testrepository>=0.0.18
   testtools>=1.4.0
+  python-openstackclient
 
 doc =
   sphinx!=1.2.0,!=1.3b1,>=1.1.2


### PR DESCRIPTION
We have no functional test for the OSC client.

This change add one to ensure we can really setup the osc client plugin.

For this, we fix two things:
* the missing get_auth_ref() for our custom keystonauth plugin
  this method need to be implemented for osc client
* replace the deprecated interface/region_name arguments by
  adapter_options equivalent.

(cherry picked from commit d486f1d0a1f18033634b9f49690799ef0a7c72f3)