### PR TITLE
Allow AP create CLI to use flexible def format

### DIFF
--- a/gnocchiclient/v1/archive_policy_cli.py
+++ b/gnocchiclient/v1/archive_policy_cli.py
@@ -54,6 +54,8 @@ def archive_policy_definition(string):
     defs = {}
     for part in parts:
         attr, __, value = part.partition(":")
+        attr.strip()
+        value.strip()
         if (attr not in ['granularity', 'points', 'timespan']
                 or value is None):
             raise ValueError


### PR DESCRIPTION
Originally `-d 'granularity:10s, points:600' is not allowed
since the space after comma. Now it'll be ok if the string
is stripped first before checking.