### PR TITLE
Change default formatting for list to YAML

### DIFF
--- a/gnocchiclient/utils.py
+++ b/gnocchiclient/utils.py
@@ -11,6 +11,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+from cliff import lister
 from dateutil import tz
 import iso8601
 import pyparsing as pp
@@ -242,3 +243,11 @@ def parse_date(s):
 
 def dt_to_localtz(d):
     return d.astimezone(LOCAL_TIMEZONE)
+
+
+class Lister(lister.Lister):
+    """Cliff lister that uses yaml by default."""
+
+    @property
+    def formatter_default(self):
+        return 'yaml'

--- a/gnocchiclient/v1/aggregates_cli.py
+++ b/gnocchiclient/v1/aggregates_cli.py
@@ -10,13 +10,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
-from cliff import lister
-
 from gnocchiclient import utils
 
 
-class CliAggregates(lister.Lister):
+class CliAggregates(utils.Lister):
     """Get measurements of aggregated metrics"""
 
     COLS = ('name', 'timestamp', 'granularity', 'value')

--- a/gnocchiclient/v1/archive_policy_cli.py
+++ b/gnocchiclient/v1/archive_policy_cli.py
@@ -12,13 +12,12 @@
 #    under the License.
 
 from cliff import command
-from cliff import lister
 from cliff import show
 
 from gnocchiclient import utils
 
 
-class CliArchivePolicyList(lister.Lister):
+class CliArchivePolicyList(utils.Lister):
     """List archive policies"""
 
     COLS = ('name',
@@ -26,9 +25,6 @@ class CliArchivePolicyList(lister.Lister):
 
     def take_action(self, parsed_args):
         policies = utils.get_client(self).archive_policy.list()
-        if parsed_args.formatter == 'table':
-            for ap in policies:
-                utils.format_archive_policy(ap)
         return utils.list2cols(self.COLS, policies)
 
 

--- a/gnocchiclient/v1/archive_policy_rule_cli.py
+++ b/gnocchiclient/v1/archive_policy_rule_cli.py
@@ -12,13 +12,12 @@
 #    under the License.
 
 from cliff import command
-from cliff import lister
 from cliff import show
 
 from gnocchiclient import utils
 
 
-class CliArchivePolicyRuleList(lister.Lister):
+class CliArchivePolicyRuleList(utils.Lister):
     """List archive policy rules"""
 
     COLS = ('name', 'archive_policy_name', 'metric_pattern')

--- a/gnocchiclient/v1/metric_cli.py
+++ b/gnocchiclient/v1/metric_cli.py
@@ -16,7 +16,6 @@ import logging
 import sys
 
 from cliff import command
-from cliff import lister
 from cliff import show
 
 from gnocchiclient import utils
@@ -33,7 +32,7 @@ class CliMetricWithResourceID(command.Command):
         return parser
 
 
-class CliMetricList(lister.Lister):
+class CliMetricList(utils.Lister):
     """List metrics"""
 
     COLS = ('id', 'archive_policy/name', 'name', 'unit', 'resource_id')
@@ -169,7 +168,7 @@ class DeprecatedCliMetricDelete(CliMetricDelete):
         return super(DeprecatedCliMetricDelete, self).take_action(parsed_args)
 
 
-class CliMeasuresReturn(lister.Lister):
+class CliMeasuresReturn(utils.Lister):
     def get_parser(self, prog_name):
         parser = super(CliMeasuresReturn, self).get_parser(prog_name)
         parser.add_argument("--utc", help="Return timestamps as UTC",
@@ -186,8 +185,7 @@ class CliMeasuresReturn(lister.Lister):
         return [(t(dt).isoformat(), g, v) for dt, g, v in measures]
 
 
-class CliMeasuresShow(CliMetricWithResourceID, CliMeasuresReturn,
-                      lister.Lister):
+class CliMeasuresShow(CliMetricWithResourceID, CliMeasuresReturn):
     """Get measurements of a metric"""
 
     COLS = ('timestamp', 'granularity', 'value')

--- a/gnocchiclient/v1/resource_cli.py
+++ b/gnocchiclient/v1/resource_cli.py
@@ -14,14 +14,13 @@
 import distutils.util
 
 from cliff import command
-from cliff import lister
 from cliff import show
 
 from gnocchiclient import exceptions
 from gnocchiclient import utils
 
 
-class CliResourceList(lister.Lister):
+class CliResourceList(utils.Lister):
     """List resources"""
 
     COLS = ('id', 'type',

--- a/gnocchiclient/v1/resource_type_cli.py
+++ b/gnocchiclient/v1/resource_type_cli.py
@@ -14,13 +14,12 @@
 import distutils.util
 
 from cliff import command
-from cliff import lister
 from cliff import show
 
 from gnocchiclient import utils
 
 
-class CliResourceTypeList(lister.Lister):
+class CliResourceTypeList(utils.Lister):
     """List resource types"""
 
     COLS = ('name', 'attributes')


### PR DESCRIPTION
The default table output is never big enough to accommodate the output width.
YAML outputs always fits into a screen and is easy enough for human to read.