### PR TITLE
tests: use a fixture to fake TZ in environ

### DIFF
--- a/gnocchiclient/tests/functional/test_metric.py
+++ b/gnocchiclient/tests/functional/test_metric.py
@@ -14,6 +14,8 @@ import os
 import tempfile
 import uuid
 
+import fixtures
+
 from gnocchiclient import auth
 from gnocchiclient import client
 from gnocchiclient.tests.functional import base
@@ -95,7 +97,7 @@ class MetricClientTest(base.ClientTestBase):
                      % metric["id"], has_output=False)
 
         # MEASURES SHOW
-        os.environ["TZ"] = "Europe/Paris"
+        self.useFixture(fixtures.EnvironmentVariable("TZ", "Europe/Paris"))
         result = self.gnocchi('measures', params="show --refresh " +
                               metric["id"])
         measures = json.loads(result)

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,6 +80,7 @@ openstack.metric.v1 =
 [extras]
 test =
   testtools>=1.4.0
+  fixtures
   python-openstackclient
   pytest
   pytest-xdist


### PR DESCRIPTION
Otherwise some tests will be broken because it is never cleaned up later.