### PR TITLE
Only run tests on pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,15 @@ env:
   - TARGET: docs-gnocchi.xyz
 
 before_script:
-  - docker pull gnocchixyz/ci-tools:latest
+  # Only run if this is a pull-request
+  - if \[ "$TRAVIS_PULL_REQUEST" != "false" -o  -n "$TRAVIS_TAG" \]; then
+      docker pull gnocchixyz/ci-tools:latest ;
+    fi
 script:
-  - docker run -v ~/.cache/pip:/home/tester/.cache/pip -v $(pwd):/home/tester/src gnocchixyz/ci-tools:latest tox -e ${TARGET}
+  # Only run if this is a pull-request
+  - if \[ "$TRAVIS_PULL_REQUEST" != "false" -o  -n "$TRAVIS_TAG" \]; then
+      docker run -v ~/.cache/pip:/home/tester/.cache/pip -v $(pwd):/home/tester/src gnocchixyz/ci-tools:latest tox -e ${TARGET} ;
+    fi
 
 notifications:
   email: false


### PR DESCRIPTION
Since we configure Travis to run on every push and tag (for release), we now
need to check if we need to do anything else.

If this is not a PR, no need to run the tests.