### PR TITLE
Set the Cliff namespace

### DIFF
--- a/gnocchiclient/shell.py
+++ b/gnocchiclient/shell.py
@@ -94,7 +94,7 @@ class GnocchiShell(app.App):
         super(GnocchiShell, self).__init__(
             description='Gnocchi command line client',
             version=__version__,
-            command_manager=GnocchiCommandManager(None),
+            command_manager=GnocchiCommandManager('gnocchiclient'),
             deferred_help=True,
         )
 


### PR DESCRIPTION
Setting None as namespace was working by chance. Cliff was using it only
in a method we override. But since 2.10, it uses in some other place.

This change put a valid name as cliff namespace.