### PR TITLE
Avoid using openstack-doc-tools

### DIFF
--- a/doc/source/shell.rst
+++ b/doc/source/shell.rst
@@ -72,4 +72,8 @@ client time zone.
 Commands descriptions
 +++++++++++++++++++++
 
-.. include:: gnocchi.rst
+.. autodoc-gnocchi:: gnocchiclient.shell.GnocchiShell
+   :application: gnocchi
+
+.. autodoc-gnocchi:: openstack.metric.v1
+   :application: gnocchi

--- a/gnocchiclient/gendoc.py
+++ b/gnocchiclient/gendoc.py
@@ -14,60 +14,27 @@
 
 from __future__ import absolute_import
 
-import sys
+import fnmatch
 
-from os_doc_tools import commands
+from cliff import sphinxext
 
 from gnocchiclient import shell
 
-# HACK(jd) Not sure why but Sphinx setup this multiple times, so we just avoid
-# doing several times the requests by using this global variable :(
-_RUN = False
 
-
-def get_clients():
-    return {'gnocchi': {
-        'name': 'A time series storage and resources index service (Gnocchi)',
-    }}
-
-
-def discover_subcommands(os_command, subcommands, extra_params):
-    return shell.GnocchiCommandManager.SHELL_COMMANDS.keys()
+class GnocchiAutoDocDirective(sphinxext.AutoprogramCliffDirective):
+    def _load_commands(self):
+        command_pattern = self.options.get('command')
+        full_cmd_list = shell.GnocchiCommandManager.SHELL_COMMANDS.keys()
+        if command_pattern:
+            commands = [x for x in full_cmd_list
+                        if fnmatch.fnmatch(x, command_pattern)]
+        else:
+            commands = full_cmd_list
+        return dict((name, shell.GnocchiCommandManager.SHELL_COMMANDS[name])
+                    for name in commands)
 
 
 def setup(app):
-    global _RUN
-    if _RUN:
-        return
-
-    output_dir = "doc/source"
-    os_command = 'gnocchi'
-    print("Documenting '%s'" % os_command)
-
-    api_name = "Gnocchi API"
-    title = "Gnocchi command-line client"
-
-    out_filename = os_command + ".rst"
-    out_file = commands.generate_heading(os_command, api_name, title,
-                                         output_dir, out_filename,
-                                         False)
-    if not out_file:
-        sys.exit(-1)
-
-    commands.generate_command(os_command, out_file)
-    commands.generate_subcommands(
-        os_command, out_file,
-        list(sorted(shell.GnocchiCommandManager.SHELL_COMMANDS.keys())),
-        None, "", "")
-
-    print("Finished.\n")
-    out_file.close()
-
-    with open("doc/source/gnocchi.rst", "r") as f:
-        data = f.read().splitlines(True)
-        for index, line in enumerate(data):
-            if "This chapter documents" in line:
-                break
-    with open("doc/source/gnocchi.rst", "w") as f:
-        f.writelines(data[index + 1:])
-    _RUN = True
+    app.add_directive('autodoc-gnocchi', GnocchiAutoDocDirective)
+    app.add_config_value('autoprogram_cliff_application', 'gnocchi', True)
+    app.add_config_value('autoprogram_cliff_ignored', ['--help'], True)

--- a/gnocchiclient/tests/functional/test_osc.py
+++ b/gnocchiclient/tests/functional/test_osc.py
@@ -22,4 +22,4 @@ class OpenstackClentPluginTest(base.ClientTestBase):
     def test_osc_client(self):
         result = self.openstack("metric status")
         status = json.loads(result)
-        self.assertEqual(2, len(status))
+        self.assertGreaterEqual(3, len(status))

--- a/gnocchiclient/tests/functional/test_others.py
+++ b/gnocchiclient/tests/functional/test_others.py
@@ -18,7 +18,7 @@ class MetricClientTest(base.ClientTestBase):
     def test_status_scenario(self):
         result = self.gnocchi("status")
         status = json.loads(result)
-        self.assertEqual(2, len(status))
+        self.assertGreaterEqual(3, len(status))
 
     def test_build_scenario(self):
         result = self.gnocchi("server version")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # process, which may cause wedges in the gate later.
 
 pbr>=1.4
-cliff>1.16.0 # Apache-2.0
+cliff>=2.10 # Apache-2.0
 ujson
 keystoneauth1>=2.0.0
 six

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,7 +89,6 @@ test =
 doc =
   sphinx!=1.2.0,!=1.3b1,>=1.1.2
   sphinx_rtd_theme
-  openstack-doc-tools>=1.0.1
 
 openstack =
   osc-lib>=0.3.0 # Apache-2.0


### PR DESCRIPTION
This patch remove usage of os_doc_tools.command and utilizes
cliff.sphinxext with minor modification.

The modification is required because original CommandManager
does not see gnocchi commands for some reason.

Fixes issue #80.