### PR TITLE
Remove hacking dependency for pep8

### DIFF
--- a/gnocchiclient/auth.py
+++ b/gnocchiclient/auth.py
@@ -19,12 +19,13 @@ from keystoneauth1 import plugin
 
 
 class GnocchiNoAuthPlugin(plugin.BaseAuthPlugin):
-    """No authentication plugin for Gnocchi
+    """No authentication plugin for Gnocchi.
 
     This is a keystoneauth plugin that instead of
     doing authentication, it just fill the 'x-user-id'
     and 'x-project-id' headers with the user provided one.
     """
+
     def __init__(self, user_id, project_id, roles, endpoint):
         self._user_id = user_id
         self._project_id = project_id
@@ -88,6 +89,7 @@ class GnocchiNoAuthLoader(loading.BaseLoader):
 
 class GnocchiBasicPlugin(plugin.BaseAuthPlugin):
     """Basic authentication plugin for Gnocchi."""
+
     def __init__(self, user, endpoint):
         self._user = user.encode('utf-8')
         self._endpoint = endpoint

--- a/gnocchiclient/benchmark.py
+++ b/gnocchiclient/benchmark.py
@@ -22,9 +22,13 @@ import time
 import types
 
 from cliff import show
+
 import futurist
+
 import iso8601
+
 from monotonic import monotonic as now  # noqa
+
 import six.moves
 
 from gnocchiclient import utils
@@ -121,16 +125,15 @@ class BenchmarkPool(futurist.ProcessPoolExecutor):
             verb + ' runtime (cumulated)': "%.2f seconds" % sum(latencies),
             verb + ' executed': self.statistics.executed,
             verb + ' speed': (
-                "%.2f %s/s" % ((self.statistics.executed * self._max_workers
-                                / sum(latencies))
+                "%.2f %s/s" % ((self.statistics.executed * self._max_workers /
+                                sum(latencies))
                                if runtime != 0 else 0, verb)
             ),
             verb + ' failures': self.statistics.failures,
             verb + ' failures rate': (
                 "%.2f %%" % (
-                    100
-                    * self.statistics.failures
-                    / float(self.statistics.executed)
+                    100 * self.statistics.failures /
+                    float(self.statistics.executed)
                 )
             ),
             verb + ' latency min': min(latencies),
@@ -170,7 +173,7 @@ class CliBenchmarkBase(show.ShowOne):
 
 class CliBenchmarkMetricShow(CliBenchmarkBase,
                              metric_cli.CliMetricWithResourceID):
-    """Do benchmark testing of metric show"""
+    """Do benchmark testing of metric show."""
 
     def get_parser(self, prog_name):
         parser = super(CliBenchmarkMetricShow, self).get_parser(prog_name)
@@ -194,7 +197,7 @@ class CliBenchmarkMetricShow(CliBenchmarkBase,
 
 class CliBenchmarkMetricCreate(CliBenchmarkBase,
                                metric_cli.CliMetricCreateBase):
-    """Do benchmark testing of metric creation"""
+    """Do benchmark testing of metric creation."""
 
     def get_parser(self, prog_name):
         parser = super(CliBenchmarkMetricCreate, self).get_parser(prog_name)
@@ -231,7 +234,7 @@ class CliBenchmarkMetricCreate(CliBenchmarkBase,
 
 class CliBenchmarkMeasuresAdd(CliBenchmarkBase,
                               metric_cli.CliMeasuresAddBase):
-    """Do benchmark testing of adding measurements"""
+    """Do benchmark testing of adding measurements."""
 
     def get_parser(self, prog_name):
         parser = super(CliBenchmarkMeasuresAdd, self).get_parser(prog_name)
@@ -245,8 +248,8 @@ class CliBenchmarkMeasuresAdd(CliBenchmarkBase,
                             help="Number of measures to send in each batch")
         parser.add_argument("--timestamp-start", "-s",
                             default=(
-                                datetime.datetime.now(tz=iso8601.iso8601.UTC)
-                                - datetime.timedelta(days=365)),
+                                datetime.datetime.now(tz=iso8601.iso8601.UTC) -
+                                datetime.timedelta(days=365)),
                             type=utils.parse_date,
                             help="First timestamp to use")
         parser.add_argument("--timestamp-end", "-e",
@@ -326,7 +329,7 @@ class CliBenchmarkMeasuresAdd(CliBenchmarkBase,
 
 class CliBenchmarkMeasuresShow(CliBenchmarkBase,
                                metric_cli.CliMeasuresShow):
-    """Do benchmark testing of measurements show"""
+    """Do benchmark testing of measurements show."""
 
     def get_parser(self, prog_name):
         parser = super(CliBenchmarkMeasuresShow, self).get_parser(prog_name)

--- a/gnocchiclient/exceptions.py
+++ b/gnocchiclient/exceptions.py
@@ -18,6 +18,7 @@ import six
 
 class ClientException(Exception):
     """The base exception class for all exceptions this library raises."""
+
     message = 'Unknown Error'
 
     def __init__(self, code=None, message=None, request_id=None,
@@ -39,6 +40,7 @@ class ClientException(Exception):
 
 class RetryAfterException(ClientException):
     """The base exception for ClientExceptions that use Retry-After header."""
+
     def __init__(self, *args, **kwargs):
         try:
             self.retry_after = int(kwargs.pop('retry_after'))
@@ -49,44 +51,48 @@ class RetryAfterException(ClientException):
 
 
 class ConnectionFailure(ClientException):
-    """Connection failure"""
+    """Connection failure."""
 
 
 class ConnectionTimeout(ClientException):
-    """Connection timeout"""
+    """Connection timeout."""
 
 
 class UnknownConnectionError(ClientException):
-    """Unknown connection error"""
+    """Unknown connection error."""
 
 
 class SSLError(ClientException):
-    """SSL connection error"""
+    """SSL connection error."""
 
 
 class BadRequest(ClientException):
     """HTTP 400 - Bad request: you sent some malformed data."""
+
     http_status = 400
     message = "Bad request"
 
 
 class Unauthorized(ClientException):
     """HTTP 401 - Unauthorized: bad credentials."""
+
     http_status = 401
     message = "Unauthorized"
 
 
 class Forbidden(ClientException):
-    """HTTP 403 - Forbidden:
+    """HTTP 403 - Forbidden.
 
-    your credentials don't give you access to this resource.
+    Your credentials don't give you access to this resource.
     """
+
     http_status = 403
     message = "Forbidden"
 
 
 class NotFound(ClientException):
-    """HTTP 404 - Not found"""
+    """HTTP 404 - Not found."""
+
     http_status = 404
     message = "Not found"
 
@@ -117,19 +123,22 @@ class ArchivePolicyRuleNotFound(NotFound):
 
 
 class MethodNotAllowed(ClientException):
-    """HTTP 405 - Method Not Allowed"""
+    """HTTP 405 - Method Not Allowed."""
+
     http_status = 405
     message = "Method Not Allowed"
 
 
 class NotAcceptable(ClientException):
-    """HTTP 406 - Not Acceptable"""
+    """HTTP 406 - Not Acceptable."""
+
     http_status = 406
     message = "Not Acceptable"
 
 
 class Conflict(ClientException):
-    """HTTP 409 - Conflict"""
+    """HTTP 409 - Conflict."""
+
     http_status = 409
     message = "Conflict"
 
@@ -160,28 +169,31 @@ class ArchivePolicyRuleAlreadyExists(Conflict):
 
 
 class OverLimit(RetryAfterException):
-    """HTTP 413 - Over limit:
+    """HTTP 413 - Over limit.
 
-    you're over the API limits for this time period.
+    You're over the API limits for this time period.
     """
+
     http_status = 413
     message = "Over limit"
 
 
 class RateLimit(RetryAfterException):
-    """HTTP 429 - Rate limit:
+    """HTTP 429 - Rate limit.
 
-    you've sent too many requests for this time period.
+    You've sent too many requests for this time period.
     """
+
     http_status = 429
     message = "Rate limit"
 
 
-class NotImplemented(ClientException):
-    """HTTP 501 - Not Implemented:
+class NotImplemented(ClientException):  # noqa
+    """HTTP 501 - Not Implemented.
 
-    the server does not support this operation.
+    The server does not support this operation.
     """
+
     http_status = 501
     message = "Not Implemented"
 
@@ -211,7 +223,6 @@ def from_response(response, method=None):
         if resp.status_code != 200:
             raise from_response(resp)
     """
-
     if response.status_code:
         cls, enhanced_classes = _code_map.get(response.status_code,
                                               (ClientException, []))

--- a/gnocchiclient/osc.py
+++ b/gnocchiclient/osc.py
@@ -24,7 +24,7 @@ API_VERSIONS = {
 
 
 def make_client(instance):
-    """Returns a metrics service client."""
+    """Return a metrics service client."""
     version = instance._api_version[API_NAME]
     try:
         version = int(version)
@@ -45,7 +45,7 @@ def make_client(instance):
 
 
 def build_option_parser(parser):
-    """Hook to add global options."""
+    """Add global options to the parser."""
     parser.add_argument(
         '--os-metrics-api-version',
         metavar='<metrics-api-version>',

--- a/gnocchiclient/shell.py
+++ b/gnocchiclient/shell.py
@@ -20,6 +20,7 @@ import warnings
 
 from cliff import app
 from cliff import commandmanager
+
 from keystoneauth1 import adapter
 from keystoneauth1 import exceptions
 from keystoneauth1 import loading

--- a/gnocchiclient/tests/functional/base.py
+++ b/gnocchiclient/tests/functional/base.py
@@ -12,10 +12,11 @@
 
 import os
 import shlex
-import six
 import subprocess
 import time
 import unittest
+
+import six
 
 
 class ClientTestBase(unittest.TestCase):
@@ -35,8 +36,7 @@ class ClientTestBase(unittest.TestCase):
                   has_output=True):
         flags = ((("--os-auth-type gnocchi-basic "
                    "--os-user admin "
-                   "--os-endpoint %s") % self.endpoint)
-                 + ' ' + flags)
+                   "--os-endpoint %s") % self.endpoint) + ' ' + flags)
         return self._run("openstack", action, flags, params, fail_ok,
                          merge_stderr, input, has_output)
 
@@ -45,8 +45,7 @@ class ClientTestBase(unittest.TestCase):
                 has_output=True):
         flags = ((("--os-auth-plugin gnocchi-basic "
                    "--user admin "
-                   "--endpoint %s") % self.endpoint)
-                 + ' ' + flags)
+                   "--endpoint %s") % self.endpoint) + ' ' + flags)
         return self._run("gnocchi", action, flags, params, fail_ok,
                          merge_stderr, input, has_output)
 

--- a/gnocchiclient/tests/functional/test_metric.py
+++ b/gnocchiclient/tests/functional/test_metric.py
@@ -16,8 +16,8 @@ import uuid
 
 from gnocchiclient import auth
 from gnocchiclient import client
-from gnocchiclient.tests.functional import base
 from gnocchiclient import utils
+from gnocchiclient.tests.functional import base
 
 
 class MetricClientTest(base.ClientTestBase):

--- a/gnocchiclient/utils.py
+++ b/gnocchiclient/utils.py
@@ -12,7 +12,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 from dateutil import tz
+
 import iso8601
+
 import six
 from six.moves.urllib import parse as urllib_parse
 

--- a/gnocchiclient/v1/aggregates.py
+++ b/gnocchiclient/v1/aggregates.py
@@ -14,6 +14,7 @@
 import datetime
 
 import iso8601
+
 import ujson
 
 from gnocchiclient import utils
@@ -24,7 +25,7 @@ class AggregatesManager(base.Manager):
     def fetch(self, operations, search=None,
               resource_type='generic', start=None, stop=None, granularity=None,
               needed_overlap=None, groupby=None, fill=None, details=False):
-        """Get measurements of an aggregated metrics
+        """Get measurements of an aggregated metrics.
 
         :param operations: operations
         :type operations: list or str
@@ -48,7 +49,6 @@ class AggregatesManager(base.Manager):
         of *query dictionary*
         http://docs.openstack.org/developer/gnocchi/rest.html#aggregates
         """
-
         if isinstance(start, datetime.datetime):
             start = start.isoformat()
         if isinstance(stop, datetime.datetime):

--- a/gnocchiclient/v1/aggregates_cli.py
+++ b/gnocchiclient/v1/aggregates_cli.py
@@ -17,7 +17,7 @@ from gnocchiclient import utils
 
 
 class CliAggregates(lister.Lister):
-    """Get measurements of aggregated metrics"""
+    """Get measurements of aggregated metrics."""
 
     COLS = ('name', 'timestamp', 'granularity', 'value')
 

--- a/gnocchiclient/v1/archive_policy.py
+++ b/gnocchiclient/v1/archive_policy.py
@@ -21,13 +21,11 @@ class ArchivePolicyManager(base.Manager):
     url = "v1/archive_policy/"
 
     def list(self):
-        """List archive policies
-
-        """
+        """List archive policies."""
         return self._get(self.url).json()
 
     def get(self, name):
-        """Get an archive policy
+        """Get an archive policy.
 
         :param name: Name of the archive policy
         :type name: str
@@ -35,7 +33,7 @@ class ArchivePolicyManager(base.Manager):
         return self._get(self.url + name).json()
 
     def create(self, archive_policy):
-        """Create an archive policy
+        """Create an archive policy.
 
         :param archive_policy: the archive policy
         :type archive_policy: dict
@@ -46,7 +44,7 @@ class ArchivePolicyManager(base.Manager):
             data=ujson.dumps(archive_policy)).json()
 
     def update(self, name, archive_policy):
-        """Update an archive policy
+        """Update an archive policy.
 
         :param name: the name of archive policy
         :type name: str
@@ -60,7 +58,7 @@ class ArchivePolicyManager(base.Manager):
             data=ujson.dumps(archive_policy)).json()
 
     def delete(self, name):
-        """Delete an archive policy
+        """Delete an archive policy.
 
         :param name: Name of the archive policy
         :type name: str

--- a/gnocchiclient/v1/archive_policy_cli.py
+++ b/gnocchiclient/v1/archive_policy_cli.py
@@ -19,7 +19,7 @@ from gnocchiclient import utils
 
 
 class CliArchivePolicyList(lister.Lister):
-    """List archive policies"""
+    """List archive policies."""
 
     COLS = ('name',
             'back_window', 'definition', 'aggregation_methods')
@@ -33,7 +33,7 @@ class CliArchivePolicyList(lister.Lister):
 
 
 class CliArchivePolicyShow(show.ShowOne):
-    """Show an archive policy"""
+    """Show an archive policy."""
 
     def get_parser(self, prog_name):
         parser = super(CliArchivePolicyShow, self).get_parser(prog_name)
@@ -54,8 +54,8 @@ def archive_policy_definition(string):
     defs = {}
     for part in parts:
         attr, __, value = part.partition(":")
-        if (attr not in ['granularity', 'points', 'timespan']
-                or value is None):
+        if (attr not in ['granularity', 'points', 'timespan'] or
+           value is None):
             raise ValueError
         defs[attr] = value
     if len(defs) < 2:
@@ -77,7 +77,7 @@ class CliArchivePolicyWriteBase(show.ShowOne):
 
 
 class CliArchivePolicyCreate(CliArchivePolicyWriteBase):
-    """Create an archive policy"""
+    """Create an archive policy."""
 
     def get_parser(self, prog_name):
         parser = super(CliArchivePolicyCreate, self).get_parser(prog_name)
@@ -102,7 +102,7 @@ class CliArchivePolicyCreate(CliArchivePolicyWriteBase):
 
 
 class CliArchivePolicyUpdate(CliArchivePolicyWriteBase):
-    """Update an archive policy"""
+    """Update an archive policy."""
 
     def take_action(self, parsed_args):
         archive_policy = utils.dict_from_parsed_args(
@@ -115,7 +115,7 @@ class CliArchivePolicyUpdate(CliArchivePolicyWriteBase):
 
 
 class CliArchivePolicyDelete(command.Command):
-    """Delete an archive policy"""
+    """Delete an archive policy."""
 
     def get_parser(self, prog_name):
         parser = super(CliArchivePolicyDelete, self).get_parser(prog_name)

--- a/gnocchiclient/v1/archive_policy_rule.py
+++ b/gnocchiclient/v1/archive_policy_rule.py
@@ -17,16 +17,15 @@ from gnocchiclient.v1 import base
 
 
 class ArchivePolicyRuleManager(base.Manager):
+
     url = "v1/archive_policy_rule/"
 
     def list(self):
-        """List archive policy rules
-
-        """
+        """List archive policy rules."""
         return self._get(self.url).json()
 
     def get(self, name):
-        """Get an archive policy rules
+        """Get an archive policy rules.
 
         :param name: Name of the archive policy rule
         :type name: str
@@ -34,15 +33,13 @@ class ArchivePolicyRuleManager(base.Manager):
         return self._get(self.url + name).json()
 
     def create(self, archive_policy_rule):
-        """Create an archive policy rule
-
-        """
+        """Create an archive policy rule."""
         return self._post(
             self.url, headers={'Content-Type': "application/json"},
             data=ujson.dumps(archive_policy_rule)).json()
 
     def update(self, name, new_name):
-        """Update an archive policy rule
+        """Update an archive policy rule.
 
         :param name: the name of archive policy rule
         :type name: str
@@ -56,7 +53,7 @@ class ArchivePolicyRuleManager(base.Manager):
             data=ujson.dumps({'name': new_name})).json()
 
     def delete(self, name):
-        """Delete an archive policy rule
+        """Delete an archive policy rule.
 
         :param name: Name of the archive policy rule
         :type name: str

--- a/gnocchiclient/v1/archive_policy_rule_cli.py
+++ b/gnocchiclient/v1/archive_policy_rule_cli.py
@@ -19,7 +19,7 @@ from gnocchiclient import utils
 
 
 class CliArchivePolicyRuleList(lister.Lister):
-    """List archive policy rules"""
+    """List archive policy rules."""
 
     COLS = ('name', 'archive_policy_name', 'metric_pattern')
 
@@ -29,7 +29,7 @@ class CliArchivePolicyRuleList(lister.Lister):
 
 
 class CliArchivePolicyRuleShow(show.ShowOne):
-    """Show an archive policy rule"""
+    """Show an archive policy rule."""
 
     def get_parser(self, prog_name):
         parser = super(CliArchivePolicyRuleShow, self).get_parser(prog_name)
@@ -44,7 +44,7 @@ class CliArchivePolicyRuleShow(show.ShowOne):
 
 
 class CliArchivePolicyRuleCreate(show.ShowOne):
-    """Create an archive policy rule"""
+    """Create an archive policy rule."""
 
     def get_parser(self, prog_name):
         parser = super(CliArchivePolicyRuleCreate, self).get_parser(prog_name)
@@ -67,7 +67,7 @@ class CliArchivePolicyRuleCreate(show.ShowOne):
 
 
 class CliArchivePolicyRuleUpdate(show.ShowOne):
-    """Update an archive policy rule"""
+    """Update an archive policy rule."""
 
     def get_parser(self, prog_name):
         parser = super(CliArchivePolicyRuleUpdate, self).get_parser(prog_name)
@@ -87,7 +87,7 @@ class CliArchivePolicyRuleUpdate(show.ShowOne):
 
 
 class CliArchivePolicyRuleDelete(command.Command):
-    """Delete an archive policy rule"""
+    """Delete an archive policy rule."""
 
     def get_parser(self, prog_name):
         parser = super(CliArchivePolicyRuleDelete, self).get_parser(prog_name)

--- a/gnocchiclient/v1/build_cli.py
+++ b/gnocchiclient/v1/build_cli.py
@@ -17,7 +17,7 @@ from gnocchiclient import utils
 
 
 class CliBuildShow(show.ShowOne):
-    """Show the version of Gnocchi server"""
+    """Show the version of Gnocchi server."""
 
     def take_action(self, parsed_args):
         return self.dict2columns({

--- a/gnocchiclient/v1/capabilities.py
+++ b/gnocchiclient/v1/capabilities.py
@@ -18,7 +18,5 @@ class CapabilitiesManager(base.Manager):
     cap_url = "v1/capabilities/"
 
     def list(self):
-        """List capabilities
-
-        """
+        """List capabilities."""
         return self._get(self.cap_url).json()

--- a/gnocchiclient/v1/capabilities_cli.py
+++ b/gnocchiclient/v1/capabilities_cli.py
@@ -17,7 +17,7 @@ from gnocchiclient import utils
 
 
 class CliCapabilitiesList(show.ShowOne):
-    """List capabilities"""
+    """List capabilities."""
 
     def take_action(self, parsed_args):
         caps = utils.get_client(self).capabilities.list()

--- a/gnocchiclient/v1/metric.py
+++ b/gnocchiclient/v1/metric.py
@@ -15,7 +15,9 @@ import datetime
 import uuid
 
 from debtcollector import removals
+
 import iso8601
+
 import ujson
 
 from gnocchiclient import utils
@@ -29,7 +31,7 @@ class MetricManager(base.Manager):
     resources_batch_url = "v1/batch/resources/metrics/measures"
 
     def list(self, limit=None, marker=None, sorts=None):
-        """List metrics
+        """List metrics.
 
         :param limit: maximum number of resources to return
         :type limit: int
@@ -63,7 +65,7 @@ class MetricManager(base.Manager):
                             attribute)
 
     def get(self, metric, resource_id=None):
-        """Get an metric
+        """Get an metric.
 
         :param metric: ID or Name of the metric
         :type metric: str
@@ -83,7 +85,7 @@ class MetricManager(base.Manager):
     # pickle a debtcollector-ed method.
     def _create_new(self, name=None, archive_policy_name=None,
                     resource_id=None, unit=None):
-        """Create an metric
+        """Create an metric.
 
         :param name: Metric name.
         :type name: str
@@ -94,7 +96,6 @@ class MetricManager(base.Manager):
         :param unit: The unit of the metric.
         :type unit: str
         """
-
         metric = {}
         if name is not None:
             metric["name"] = name
@@ -125,7 +126,7 @@ class MetricManager(base.Manager):
                archive_policy_name=None,
                resource_id=None,
                unit=None):
-        """Create an metric
+        """Create an metric.
 
         :param name: Metric name.
         :type name: str
@@ -136,7 +137,6 @@ class MetricManager(base.Manager):
         :param unit: The unit of the metric.
         :type unit: str
         """
-
         if metric is None:
             metric = {}
             if name is not None:
@@ -174,7 +174,7 @@ class MetricManager(base.Manager):
         return self.get(metric_name, resource_id)
 
     def delete(self, metric, resource_id=None):
-        """Delete an metric
+        """Delete an metric.
 
         :param metric: ID or Name of the metric
         :type metric: str
@@ -190,7 +190,7 @@ class MetricManager(base.Manager):
         self._delete(url)
 
     def add_measures(self, metric, measures, resource_id=None):
-        """Add measurements to a metric
+        """Add measurements to a metric.
 
         :param metric: ID or Name of the metric
         :type metric: str
@@ -210,25 +210,23 @@ class MetricManager(base.Manager):
             data=ujson.dumps(measures))
 
     def batch_metrics_measures(self, measures):
-        """Add measurements to metrics
+        """Add measurements to metrics.
 
         :param measures: measurements
         :type dict(metric_id: list of dict(timestamp=timestamp, value=float))
         """
-
         return self._post(
             self.metric_batch_url,
             headers={'Content-Type': "application/json"},
             data=ujson.dumps(measures))
 
     def batch_resources_metrics_measures(self, measures, create_metrics=False):
-        """Add measurements to named metrics if resources
+        """Add measurements to named metrics if resources.
 
         :param measures: measurements
         :type dict(resource_id: dict(metric_name:
             list of dict(timestamp=timestamp, value=float)))
         """
-
         return self._post(
             self.resources_batch_url,
             headers={'Content-Type': "application/json"},
@@ -238,7 +236,7 @@ class MetricManager(base.Manager):
     def get_measures(self, metric, start=None, stop=None, aggregation=None,
                      granularity=None, resource_id=None, refresh=False,
                      resample=None, **kwargs):
-        """Get measurements of a metric
+        """Get measurements of a metric.
 
         :param metric: ID or Name of the metric
         :type metric: str
@@ -261,7 +259,6 @@ class MetricManager(base.Manager):
         All other arguments are arguments are dedicated to custom aggregation
         method passed as-is to the Gnocchi.
         """
-
         if isinstance(start, datetime.datetime):
             start = start.isoformat()
         if isinstance(stop, datetime.datetime):
@@ -285,7 +282,7 @@ class MetricManager(base.Manager):
                     reaggregation=None, granularity=None,
                     needed_overlap=None, resource_type="generic",
                     groupby=None, refresh=False, resample=None, fill=None):
-        """Get measurements of an aggregated metrics
+        """Get measurements of an aggregated metrics.
 
         :param metrics: IDs of metric or metric name
         :type metric: list or str
@@ -318,7 +315,6 @@ class MetricManager(base.Manager):
         of *query dictionary*
         http://docs.openstack.org/developer/gnocchi/rest.html#searching-for-resources
         """
-
         if isinstance(start, datetime.datetime):
             start = start.isoformat()
         if isinstance(stop, datetime.datetime):

--- a/gnocchiclient/v1/metric_cli.py
+++ b/gnocchiclient/v1/metric_cli.py
@@ -11,7 +11,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import iso8601
 import json
 import logging
 import sys
@@ -19,6 +18,8 @@ import sys
 from cliff import command
 from cliff import lister
 from cliff import show
+
+import iso8601
 
 from gnocchiclient import utils
 
@@ -35,7 +36,7 @@ class CliMetricWithResourceID(command.Command):
 
 
 class CliMetricList(lister.Lister):
-    """List metrics"""
+    """List metrics."""
 
     COLS = ('id', 'archive_policy/name', 'name', 'unit', 'resource_id')
 
@@ -62,7 +63,7 @@ class CliMetricList(lister.Lister):
 
 
 class DeprecatedCliMetricList(CliMetricList):
-    """Deprecated: List metrics"""
+    """Deprecated: List metrics."""
 
     def take_action(self, parsed_args):
         LOG_DEP.warning('This command has been deprecated. '
@@ -71,7 +72,7 @@ class DeprecatedCliMetricList(CliMetricList):
 
 
 class CliMetricShow(CliMetricWithResourceID, show.ShowOne):
-    """Show a metric"""
+    """Show a metric."""
 
     def get_parser(self, prog_name):
         parser = super(CliMetricShow, self).get_parser(prog_name)
@@ -92,7 +93,7 @@ class CliMetricShow(CliMetricWithResourceID, show.ShowOne):
 
 
 class DeprecatedCliMetricShow(CliMetricShow):
-    """Deprecated: Show a metric"""
+    """Deprecated: Show a metric."""
 
     def take_action(self, parsed_args):
         LOG_DEP.warning('This command has been deprecated. '
@@ -110,7 +111,7 @@ class CliMetricCreateBase(show.ShowOne, CliMetricWithResourceID):
 
 
 class CliMetricCreate(CliMetricCreateBase):
-    """Create a metric"""
+    """Create a metric."""
 
     def get_parser(self, prog_name):
         parser = super(CliMetricCreate, self).get_parser(prog_name)
@@ -138,7 +139,7 @@ class CliMetricCreate(CliMetricCreateBase):
 
 
 class DeprecatedCliMetricCreate(CliMetricCreate):
-    """Deprecated: Create a metric"""
+    """Deprecated: Create a metric."""
 
     def take_action(self, parsed_args):
         LOG_DEP.warning('This command has been deprecated. '
@@ -147,7 +148,7 @@ class DeprecatedCliMetricCreate(CliMetricCreate):
 
 
 class CliMetricDelete(CliMetricWithResourceID):
-    """Delete a metric"""
+    """Delete a metric."""
 
     def get_parser(self, prog_name):
         parser = super(CliMetricDelete, self).get_parser(prog_name)
@@ -162,7 +163,7 @@ class CliMetricDelete(CliMetricWithResourceID):
 
 
 class DeprecatedCliMetricDelete(CliMetricDelete):
-    """Deprecated: Delete a metric"""
+    """Deprecated: Delete a metric."""
 
     def take_action(self, parsed_args):
         LOG_DEP.warning('This command has been deprecated. '
@@ -181,7 +182,8 @@ class CliMeasuresReturn(lister.Lister):
     @staticmethod
     def format_measures_with_tz(parsed_args, measures):
         if parsed_args.utc:
-            t = lambda x: x
+            def t(x):
+                return x
         else:
             t = utils.dt_to_localtz
         return [(t(dt).isoformat(), g, v) for dt, g, v in measures]
@@ -189,7 +191,7 @@ class CliMeasuresReturn(lister.Lister):
 
 class CliMeasuresShow(CliMetricWithResourceID, CliMeasuresReturn,
                       lister.Lister):
-    """Get measurements of a metric"""
+    """Get measurements of a metric."""
 
     COLS = ('timestamp', 'granularity', 'value')
 
@@ -236,7 +238,7 @@ class CliMeasuresAddBase(CliMetricWithResourceID):
 
 
 class CliMeasuresAdd(CliMeasuresAddBase):
-    """Add measurements to a metric"""
+    """Add measurements to a metric."""
 
     def measure(self, measure):
         timestamp, __, value = measure.rpartition("@")
@@ -301,7 +303,7 @@ class CliResourcesMetricsMeasuresBatch(CliMeasuresBatch):
 
 
 class CliMeasuresAggregation(CliMeasuresReturn):
-    """Get measurements of aggregated metrics"""
+    """Get measurements of aggregated metrics."""
 
     COLS = ('timestamp', 'granularity', 'value')
 

--- a/gnocchiclient/v1/resource.py
+++ b/gnocchiclient/v1/resource.py
@@ -22,7 +22,7 @@ class ResourceManager(base.Manager):
 
     def list(self, resource_type="generic", details=False, history=False,
              limit=None, marker=None, sorts=None):
-        """List resources
+        """List resources.
 
         :param resource_type: Type of the resource
         :type resource_type: str
@@ -46,7 +46,7 @@ class ResourceManager(base.Manager):
         return self._get(url).json()
 
     def get(self, resource_type, resource_id, history=False):
-        """Get a resource
+        """Get a resource.
 
         :param resource_type: Type of the resource
         :type resource_type: str
@@ -61,7 +61,7 @@ class ResourceManager(base.Manager):
 
     def history(self, resource_type, resource_id, details=False,
                 limit=None, marker=None, sorts=None):
-        """Get a resource
+        """Get a resource.
 
         :param resource_type: Type of the resource
         :type resource_type: str
@@ -85,7 +85,7 @@ class ResourceManager(base.Manager):
         return self._get(url).json()
 
     def create(self, resource_type, resource):
-        """Create a resource
+        """Create a resource.
 
         :param resource_type: Type of the resource
         :type resource_type: str
@@ -98,7 +98,7 @@ class ResourceManager(base.Manager):
             data=ujson.dumps(resource)).json()
 
     def update(self, resource_type, resource_id, resource):
-        """Update a resource
+        """Update a resource.
 
         :param resource_type: Type of the resource
         :type resource_type: str
@@ -113,7 +113,7 @@ class ResourceManager(base.Manager):
             data=ujson.dumps(resource)).json()
 
     def delete(self, resource_id):
-        """Delete a resource
+        """Delete a resource.
 
         :param resource_id: ID of the resource
         :type resource_id: str
@@ -121,7 +121,7 @@ class ResourceManager(base.Manager):
         self._delete(self.url + "generic/" + resource_id)
 
     def batch_delete(self, query, resource_type="generic"):
-        """Delete a batch of resources based on attribute values
+        """Delete a batch of resources based on attribute values.
 
         :param resource_type: Type of the resource
         :type resource_type: str
@@ -137,7 +137,7 @@ class ResourceManager(base.Manager):
 
     def search(self, resource_type="generic", query=None, details=False,
                history=False, limit=None, marker=None, sorts=None):
-        """List resources
+        """List resources.
 
         :param resource_type: Type of the resource
         :type resource_type: str
@@ -160,7 +160,6 @@ class ResourceManager(base.Manager):
         of *query dictionary*
         http://gnocchi.xyz/rest.html#searching-for-resources
         """
-
         query = query or {}
         params = utils.build_pagination_options(
             details, history, limit, marker, sorts)

--- a/gnocchiclient/v1/resource_cli.py
+++ b/gnocchiclient/v1/resource_cli.py
@@ -22,7 +22,7 @@ from gnocchiclient import utils
 
 
 class CliResourceList(lister.Lister):
-    """List resources"""
+    """List resources."""
 
     COLS = ('id', 'type',
             'project_id', 'user_id',
@@ -74,7 +74,7 @@ class CliResourceList(lister.Lister):
 
 
 class CliResourceHistory(CliResourceList):
-    """Show the history of a resource"""
+    """Show the history of a resource."""
 
     def get_parser(self, prog_name):
         parser = super(CliResourceHistory, self).get_parser(prog_name,
@@ -94,7 +94,7 @@ class CliResourceHistory(CliResourceList):
 
 
 class CliResourceSearch(CliResourceList):
-    """Search resources with specified query rules"""
+    """Search resources with specified query rules."""
 
     def get_parser(self, prog_name):
         parser = super(CliResourceSearch, self).get_parser(prog_name)
@@ -120,7 +120,7 @@ def normalize_metrics(res):
 
 
 class CliResourceShow(show.ShowOne):
-    """Show a resource"""
+    """Show a resource."""
 
     def get_parser(self, prog_name):
         parser = super(CliResourceShow, self).get_parser(prog_name)
@@ -140,7 +140,7 @@ class CliResourceShow(show.ShowOne):
 
 
 class CliResourceCreate(show.ShowOne):
-    """Create a resource"""
+    """Create a resource."""
 
     def get_parser(self, prog_name):
         parser = super(CliResourceCreate, self).get_parser(prog_name)
@@ -176,9 +176,9 @@ class CliResourceCreate(show.ShowOne):
                 elif attr_type == "bool":
                     value = bool(distutils.util.strtobool(value))
                 resource[attr] = value
-        if (parsed_args.add_metric
-           or parsed_args.create_metric
-           or (update and parsed_args.delete_metric)):
+        if (parsed_args.add_metric or
+           parsed_args.create_metric or
+           (update and parsed_args.delete_metric)):
             if update:
                 r = utils.get_client(self).resource.get(
                     parsed_args.resource_type,
@@ -215,7 +215,7 @@ class CliResourceCreate(show.ShowOne):
 
 
 class CliResourceUpdate(CliResourceCreate):
-    """Update a resource"""
+    """Update a resource."""
 
     def get_parser(self, prog_name):
         parser = super(CliResourceUpdate, self).get_parser(prog_name)
@@ -236,7 +236,7 @@ class CliResourceUpdate(CliResourceCreate):
 
 
 class CliResourceDelete(command.Command):
-    """Delete a resource"""
+    """Delete a resource."""
 
     def get_parser(self, prog_name):
         parser = super(CliResourceDelete, self).get_parser(prog_name)
@@ -249,7 +249,7 @@ class CliResourceDelete(command.Command):
 
 
 class CliResourceBatchDelete(show.ShowOne):
-    """Delete a batch of resources based on attribute values"""
+    """Delete a batch of resources based on attribute values."""
 
     def get_parser(self, prog_name):
         parser = super(CliResourceBatchDelete, self).get_parser(prog_name)

--- a/gnocchiclient/v1/resource_type.py
+++ b/gnocchiclient/v1/resource_type.py
@@ -24,7 +24,7 @@ class ResourceTypeManager(base.Manager):
         return self._get(self.url).json()
 
     def create(self, resource_type):
-        """Create a resource type
+        """Create a resource type.
 
         :param resource_type: resource type
         :type resource_type: dict
@@ -35,7 +35,7 @@ class ResourceTypeManager(base.Manager):
             data=ujson.dumps(resource_type)).json()
 
     def get(self, name):
-        """Get a resource type
+        """Get a resource type.
 
         :param name: name of the resource type
         :type name: str
@@ -44,7 +44,7 @@ class ResourceTypeManager(base.Manager):
                          headers={'Content-Type': "application/json"}).json()
 
     def delete(self, name):
-        """Delete a resource type
+        """Delete a resource type.
 
         :param resource_type: Resource type
         :type resource_type: dict
@@ -52,7 +52,7 @@ class ResourceTypeManager(base.Manager):
         self._delete(self.url + name)
 
     def update(self, name, operations):
-        """Update a resource type
+        """Update a resource type.
 
         :param name: name of the resource type
         :type name: str

--- a/gnocchiclient/v1/resource_type_cli.py
+++ b/gnocchiclient/v1/resource_type_cli.py
@@ -21,7 +21,7 @@ from gnocchiclient import utils
 
 
 class CliResourceTypeList(lister.Lister):
-    """List resource types"""
+    """List resource types."""
 
     COLS = ('name', 'attributes')
 
@@ -34,7 +34,7 @@ class CliResourceTypeList(lister.Lister):
 
 
 class CliResourceTypeCreate(show.ShowOne):
-    """Create a resource type"""
+    """Create a resource type."""
 
     def get_parser(self, prog_name):
         parser = super(CliResourceTypeCreate, self).get_parser(prog_name)
@@ -113,7 +113,7 @@ class CliResourceTypeUpdate(CliResourceTypeCreate):
 
 
 class CliResourceTypeShow(show.ShowOne):
-    """Show a resource type"""
+    """Show a resource type."""
 
     def get_parser(self, prog_name):
         parser = super(CliResourceTypeShow, self).get_parser(prog_name)
@@ -127,7 +127,7 @@ class CliResourceTypeShow(show.ShowOne):
 
 
 class CliResourceTypeDelete(command.Command):
-    """Delete a resource type"""
+    """Delete a resource type."""
 
     def get_parser(self, prog_name):
         parser = super(CliResourceTypeDelete, self).get_parser(prog_name)

--- a/gnocchiclient/v1/status_cli.py
+++ b/gnocchiclient/v1/status_cli.py
@@ -17,7 +17,7 @@ from gnocchiclient import utils
 
 
 class CliStatusShow(show.ShowOne):
-    """Show the status of measurements processing"""
+    """Show the status of measurements processing."""
 
     def take_action(self, parsed_args):
         status = utils.get_client(self).status.get()

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,13 @@ commands = pifpaf run gnocchi -- pytest {posargs:gnocchiclient/tests}
 
 [testenv:pep8]
 basepython = python3
-deps = hacking<0.13,>=0.12
+deps = flake8
+       flake8-import-order
+       flake8-blind-except
+       flake8-builtins
+       flake8-docstrings
+       flake8-rst-docstrings
+       flake8-logging-format
        doc8>=0.8.0
 commands = flake8
            doc8 --ignore-path doc/source/gnocchi.rst --ignore-path-errors doc/source/shell.rst;D000 doc/source
@@ -40,8 +46,9 @@ commands =
 
 [flake8]
 show-source = True
-ignore =
-exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build
+ignore = D100,D101,D102,D103,D104,D105,D107,A002,A003,RST304
+exclude=.git,.tox,dist,doc,*egg,build
+application-import-names = gnocchiclient
 
 [pytest]
 addopts = --verbose --numprocesses=auto


### PR DESCRIPTION
Hacking is not maintained and depends on an old flake8 version.
Switch to flake8 and a few standard extensions.