### PR TITLE
Regenerate next page url

### DIFF
--- a/gnocchiclient/v1/metric.py
+++ b/gnocchiclient/v1/metric.py
@@ -52,6 +52,10 @@ class MetricManager(base.Manager):
             metrics.extend(page.json())
             if limit is None or len(metrics) < limit:
                 page_url = page.links.get("next", {'url': None})['url']
+                if page_url and "?" in page_url:
+                    # NOTE(hyang): Regenerate with query string
+                    page_url = "%s?%s" % (self.metric_url[:-1],
+                                          page_url.split('?')[1])
             else:
                 break
         return metrics


### PR DESCRIPTION
The full page_url from response link can be wrong in some cases. Let's just use the query string with base metric_url to regenerate the next page_url.

For example, we are running gnocchi-api behind Apache Traffic Server, and the responded link can be
`http://my-cloud.com:4443/v1/metric?limit=...&marker=...` while the real page url we want to hit is `https://my-cloud.com:4443/gnocchi-api/v1/metric?limit=...&marker=...` This is because the gnocchi-api does not know the existence of ATS. I know it is a specific case where the link in response is not the actual endpoint but my point of making this patch is with the regeneration of page_url, it can at least help avoid any other unusual failure cases like ours to make metric list command more stable.