### PR TITLE
add basic formating of params for "gnocchi archive-policy update"

### DIFF
--- a/gnocchiclient/v1/archive_policy_cli.py
+++ b/gnocchiclient/v1/archive_policy_cli.py
@@ -50,7 +50,7 @@ class CliArchivePolicyShow(show.ShowOne):
 
 
 def archive_policy_definition(string):
-    parts = string.split(",")
+    parts = string.replace(" ", "").split(",")
     defs = {}
     for part in parts:
         attr, __, value = part.partition(":")


### PR DESCRIPTION
When updating a archive-policy using gnocchi command and the definition include space character, the exception is raised. The command is like this: gnocchi archive-policy update -d "granularity: 0:03:00, points: 86400" low. So the commit will fix the bug.