### PR TITLE
FIX Bug on workaround missing OS_AUTH_TYPE

### DIFF
--- a/gnocchiclient/shell.py
+++ b/gnocchiclient/shell.py
@@ -127,7 +127,7 @@ class GnocchiShell(app.App):
         # fix all the rc files of the world, workaround it here.
         if ("OS_PASSWORD" in os.environ and
                 "OS_AUTH_TYPE" not in os.environ):
-            os.environ.set("OS_AUTH_TYPE", "password")
+            os.environ["OS_AUTH_TYPE"] = "password"
 
         loading.register_session_argparse_arguments(parser=parser)
         plugin = loading.register_auth_argparse_arguments(


### PR DESCRIPTION
os.environ.set doesn't existe, must use os.environ["OS_AUTH_TYPE"] = 
for setting environnement variable
https://docs.python.org/2/library/os.html