### PR TITLE
Fix pipeline failures

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,15 +1,33 @@
-rules:
-  default:
-    protection:
-      required_status_checks:
-        strict: True
-        contexts:
-          - continuous-integration/travis-ci
-      required_pull_request_reviews:
-        required_approving_review_count: 2
-  branches:
-    stable/.*:
-      protection:
-        required_pull_request_reviews:
-          required_approving_review_count: 1
-
+pull_request_rules:
+  - name: automatic merge
+    actions:
+      merge:
+        method: rebase
+        rebase_fallback: merge
+        strict: true
+    conditions:
+    - label!=work-in-progress
+    - '#approved-reviews-by>=2'
+    - status-success=continuous-integration/travis-ci/pr
+  - name: merge backport to stable with one review
+    actions:
+      merge:
+        method: rebase
+        rebase_fallback: merge
+        strict: true
+    conditions:
+    - base~=^stable/.*
+    - label!=work-in-progress
+    - '#approved-reviews-by>=1'
+    - status-success=continuous-integration/travis-ci/pr
+  - name: automatic merge backports from Mergify
+    actions:
+      merge:
+        method: rebase
+        rebase_fallback: merge
+        strict: true
+    conditions:
+    - base~=^stable/.*
+    - label!=work-in-progress
+    - author=mergify[bot]
+    - status-success=continuous-integration/travis-ci/pr

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ before_script:
       docker pull gnocchixyz/ci-tools:latest ;
     fi
 script:
+  # ping stdout every 9 minutes or Travis kills build
+  # https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
+  - while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
   # Only run if this is a pull-request
   - if \[ "$TRAVIS_PULL_REQUEST" != "false" -o  -n "$TRAVIS_TAG" \]; then
       docker run -v ~/.cache/pip:/home/tester/.cache/pip -v $(pwd):/home/tester/src gnocchixyz/ci-tools:latest tox -e ${TARGET} ;

--- a/gnocchiclient/v1/resource_cli.py
+++ b/gnocchiclient/v1/resource_cli.py
@@ -198,10 +198,11 @@ class CliResourceCreate(show.ShowOne):
                 resource['metrics'][name] = value
             for metric in parsed_args.create_metric:
                 name, _, value = metric.partition(":")
-                if value is "":
-                    resource['metrics'][name] = {}
-                else:
+                if value:
                     resource['metrics'][name] = {'archive_policy_name': value}
+                else:
+                    resource['metrics'][name] = {}
+                    
 
         return resource
 

--- a/gnocchiclient/v1/resource_cli.py
+++ b/gnocchiclient/v1/resource_cli.py
@@ -202,8 +202,6 @@ class CliResourceCreate(show.ShowOne):
                     resource['metrics'][name] = {'archive_policy_name': value}
                 else:
                     resource['metrics'][name] = {}
-                    
-
         return resource
 
     def take_action(self, parsed_args):


### PR DESCRIPTION
This PR accomplishes the following:

1.  Ping stdout every 10 minutes to fix 
`No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.` error
2. Update to Mergify v2 engine
3.  Fix the below pep8 error
`gnocchiclient/v1/resource_cli.py:201:20: F632 use ==/!= to compare str, bytes, and int literals`