### PR TITLE
Don't use */* in accept header

### DIFF
--- a/gnocchiclient/utils.py
+++ b/gnocchiclient/utils.py
@@ -38,15 +38,15 @@ def list2cols(cols, objs):
                   for o in objs]
 
 
-def format_string_list(l):
-    return ", ".join(l)
+def format_string_list(li):
+    return ", ".join(li)
 
 
-def format_dict_list(l):
+def format_dict_list(li):
     return "\n".join(
         "- " + ", ".join("%s: %s" % (k, v)
                          for k, v in elem.items())
-        for elem in l)
+        for elem in li)
 
 
 def format_dict_dict(value):

--- a/gnocchiclient/v1/base.py
+++ b/gnocchiclient/v1/base.py
@@ -18,7 +18,7 @@ import six
 
 class Manager(object):
     DEFAULT_HEADERS = {
-        "Accept": "application/json, */*",
+        "Accept": "application/json",
     }
 
     def __init__(self, client):

--- a/gnocchiclient/v1/resource_cli.py
+++ b/gnocchiclient/v1/resource_cli.py
@@ -198,10 +198,10 @@ class CliResourceCreate(show.ShowOne):
                 resource['metrics'][name] = value
             for metric in parsed_args.create_metric:
                 name, _, value = metric.partition(":")
-                if value is "":
-                    resource['metrics'][name] = {}
-                else:
+                if value:
                     resource['metrics'][name] = {'archive_policy_name': value}
+                else:
+                    resource['metrics'][name] = {}
 
         return resource
 


### PR DESCRIPTION
Pecan 1.4 uses accept header to decide the response content type. Let's not use */* in accept header as the response is returned as text/plain in case of exception.