### PR TITLE
setup.cfg: Replace dashes by underscores

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [metadata]
 name = gnocchiclient
 summary = Python client library for Gnocchi
-description-file =
+description_file =
     README.rst
 author = Gnocchi
-home-page = http://gnocchi.osci.io/gnocchiclient
+home_page = http://gnocchi.osci.io/gnocchiclient
 classifier =
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators


### PR DESCRIPTION
Since setuptools v54.1.0[1], the parmeters with dash have been
deprecated in favor of the new parameters with underscore.

This change updates the parameters accordingly to avoid the warnings
like the example below.

  UserWarning: Usage of dash-separated 'description-file' will not be
  supported in future versions. Please use the underscore name
  'description_file' instead

[1] https://github.com/pypa/setuptools/commit/a2e9ae4cb