### PR TITLE
Do not send Accept on most delete API calls

### DIFF
--- a/gnocchiclient/tests/functional/test_archive_policy.py
+++ b/gnocchiclient/tests/functional/test_archive_policy.py
@@ -86,6 +86,5 @@ class ArchivePolicyClientTest(base.ClientTestBase):
                               params="delete %s" % apname,
                               fail_ok=True, merge_stderr=True,
                               has_output=False)
-        self.assertEqual(
-            "Archive policy %s does not exist (HTTP 404)\n" % apname,
-            result)
+        self.assertIn("HTTP 404", result)
+        self.assertIn("Archive policy %s does not exist" % apname, result)

--- a/gnocchiclient/tests/functional/test_archive_policy_rule.py
+++ b/gnocchiclient/tests/functional/test_archive_policy_rule.py
@@ -106,6 +106,5 @@ class ArchivePolicyRuleClientTest(base.ClientTestBase):
                               params="delete test",
                               fail_ok=True, merge_stderr=True,
                               has_output=False)
-        self.assertEqual(
-            "Archive policy rule test does not exist (HTTP 404)\n",
-            result)
+        self.assertIn("HTTP 404", result)
+        self.assertIn("Archive policy rule test does not exist", result)

--- a/gnocchiclient/tests/functional/test_metric.py
+++ b/gnocchiclient/tests/functional/test_metric.py
@@ -314,9 +314,8 @@ class MetricClientTest(base.ClientTestBase):
         result = self.gnocchi('metric', params="delete %s" % metric["id"],
                               fail_ok=True, merge_stderr=True,
                               has_output=False)
-        self.assertEqual(
-            "Metric %s does not exist (HTTP 404)\n" % metric["id"],
-            result)
+        self.assertIn("HTTP 404", result)
+        self.assertIn("Metric %s does not exist" % metric["id"], result)
 
     def test_metric_by_name_scenario(self):
         # PREPARE REQUIREMENT
@@ -548,9 +547,8 @@ class MetricClientTest(base.ClientTestBase):
                               params="delete -r metric-res " + metric_name,
                               fail_ok=True, merge_stderr=True,
                               has_output=False)
-        self.assertEqual(
-            "Metric " + metric_name + " does not exist (HTTP 404)\n",
-            result)
+        self.assertIn("HTTP 404", result)
+        self.assertIn("Metric %s does not exist" % metric_name, result)
 
         # GET RESOURCE ID
         result = self.gnocchi(

--- a/gnocchiclient/tests/functional/test_resource.py
+++ b/gnocchiclient/tests/functional/test_resource.py
@@ -164,9 +164,8 @@ class ResourceClientTest(base.ClientTestBase):
                               params="delete %s" % self.RESOURCE_ID,
                               fail_ok=True, merge_stderr=True,
                               has_output=False)
-        self.assertEqual(
-            "Resource %s does not exist (HTTP 404)\n" % self.RESOURCE_ID,
-            result)
+        self.assertIn("HTTP 404", result)
+        self.assertIn("Resource %s does not exist" % self.RESOURCE_ID, result)
 
         # Create and Batch Delete
         result1 = self.gnocchi(

--- a/gnocchiclient/tests/functional/test_resource_type.py
+++ b/gnocchiclient/tests/functional/test_resource_type.py
@@ -92,9 +92,10 @@ class ResourceTypeClientTest(base.ClientTestBase):
                               params="delete %s" % self.RESOURCE_TYPE,
                               fail_ok=True, merge_stderr=True,
                               has_output=False)
-        self.assertEqual(
-            "Resource type %s does not exist (HTTP 404)\n"
-            % self.RESOURCE_TYPE,
+
+        self.assertIn("HTTP 404", result)
+        self.assertIn(
+            "Resource type %s does not exist" % self.RESOURCE_TYPE,
             result)
 
         # SHOW AGAIN

--- a/gnocchiclient/v1/archive_policy.py
+++ b/gnocchiclient/v1/archive_policy.py
@@ -63,4 +63,4 @@ class ArchivePolicyManager(base.Manager):
         :param name: Name of the archive policy
         :type name: str
         """
-        self._delete(self.url + name)
+        self._delete(self.url + name, headers={"Accept": None})

--- a/gnocchiclient/v1/archive_policy_rule.py
+++ b/gnocchiclient/v1/archive_policy_rule.py
@@ -58,4 +58,4 @@ class ArchivePolicyRuleManager(base.Manager):
         :param name: Name of the archive policy rule
         :type name: str
         """
-        self._delete(self.url + name)
+        self._delete(self.url + name, headers={"Accept": None})

--- a/gnocchiclient/v1/metric.py
+++ b/gnocchiclient/v1/metric.py
@@ -187,7 +187,7 @@ class MetricManager(base.Manager):
             url = self.metric_url + metric
         else:
             url = self.resource_url % resource_id + metric
-        self._delete(url)
+        self._delete(url, headers={"Accept": None})
 
     def add_measures(self, metric, measures, resource_id=None):
         """Add measurements to a metric.

--- a/gnocchiclient/v1/resource.py
+++ b/gnocchiclient/v1/resource.py
@@ -126,7 +126,8 @@ class ResourceManager(base.Manager):
         :param resource_id: ID of the resource
         :type resource_id: str
         """
-        self._delete(self.url + "generic/" + resource_id)
+        self._delete(self.url + "generic/" + resource_id,
+                     headers={"Accept": None})
 
     def batch_delete(self, query, resource_type="generic"):
         """Delete a batch of resources based on attribute values.

--- a/gnocchiclient/v1/resource_type.py
+++ b/gnocchiclient/v1/resource_type.py
@@ -49,7 +49,7 @@ class ResourceTypeManager(base.Manager):
         :param resource_type: Resource type
         :type resource_type: dict
         """
-        self._delete(self.url + name)
+        self._delete(self.url + name, headers={"Accept": None})
 
     def update(self, name, operations):
         """Update a resource type.


### PR DESCRIPTION
fixes #124

since  Pecan 1.4.0 (and WebOb 1.8), the validation of Accept header
became more strict.
Most delete APIs in Gnocchi are not exposed as emitting JSON
(except for resource batch delete).
On the other hand, the base Manager in gnocchiclient by default
always sends "Accept: application/json" header.

As a result, currently corresponding 'delete' gnocchiclient commands are
failing with HTTP 406 Not Acceptable when executed agains Gnocchi that
is installed with fresh versions of Pecan >= 1.4.0 as a dependency.

This patch forces gnocchiclient to explicitly send "Accept: None" header
on those DELETE API calls that do not accept JSON:
- archive policy delete
- archive policy rule delete
- resource type delete
- resource delete
- metric delete