### PR TITLE
Adjust Metrics Not Found exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ doc/source/gnocchi.rst
 
 # pytest cache
 .cache
+
+# venv of tests
+venv
+
+# ignore IDE folder
+.idea

--- a/gnocchiclient/exceptions.py
+++ b/gnocchiclient/exceptions.py
@@ -99,7 +99,7 @@ class NotFound(ClientException):
 
 class MetricNotFound(NotFound):
     message = "Metric not found"
-    match = re.compile("Metric .* does not exist|Metrics not found")
+    match = re.compile("Metric .* does not exist")
 
 
 class ResourceNotFound(NotFound):

--- a/gnocchiclient/tests/unit/test_exceptions.py
+++ b/gnocchiclient/tests/unit/test_exceptions.py
@@ -57,6 +57,26 @@ class ExceptionsTest(unittest.TestCase):
         exc = exceptions.from_response(r)
         self.assertIsInstance(exc, exceptions.ResourceTypeNotFound)
 
+    def test_metric_not_found_description_string(self):
+        r = models.Response()
+        r.status_code = 404
+        r.headers['Content-Type'] = "application/json"
+        r._content = json.dumps(
+            {"description": "Metric XXXX does not exist"}
+        ).encode('utf-8')
+        exc = exceptions.from_response(r)
+        self.assertIsInstance(exc, exceptions.MetricNotFound)
+
+    def test_metric_not_found_description_dictionary_with_data(self):
+        r = models.Response()
+        r.status_code = 404
+        r.headers['Content-Type'] = "application/json"
+        r._content = json.dumps(
+            {"description": {'cause': "Metric XXXX does not exist"}}
+        ).encode('utf-8')
+        exc = exceptions.from_response(r)
+        self.assertIsInstance(exc, exceptions.MetricNotFound)
+
     def test_from_response_keystone_401(self):
         r = models.Response()
         r.status_code = 401


### PR DESCRIPTION
Gnocchi may present one or the other response error for metrics not found depending of its version.

```
{"code": 404, "title": "Not Found", "description": {"cause": "Metrics not found", "detail": ["<metric name>"]}

```

```
{"code": 400, "description": {"cause": "Metrics not found", "detail": ["<metric name>"]}, "title": "Bad Request"}
```

Therefore, the exception handling in Gnocchi client is not correct, which causes the MetricsNotFound exception not to be presented when calling the Gnocchi Aggregates API. Instead a simple Not Found is presented to the user. This patch proposes a fix for that.

I maitained the previous workflow as well to handle situation that we have not seen yet with the description in the body as a String.