### PR TITLE
Bump github action

### DIFF
--- a/.github/workflows/python-gnocchiclient.yml
+++ b/.github/workflows/python-gnocchiclient.yml
@@ -17,7 +17,7 @@ jobs:
           - py39
           - py311
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install dependencies


### PR DESCRIPTION
actions/checkout@v2, which is a Node.js 16 action, is deprecated.