### PR TITLE
Drop implicit distutils dependency

### DIFF
--- a/gnocchiclient/utils.py
+++ b/gnocchiclient/utils.py
@@ -164,3 +164,19 @@ def parse_date(s):
 
 def dt_to_localtz(d):
     return d.astimezone(LOCAL_TIMEZONE)
+
+
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError(f"invalid truth value {val!r}")

--- a/gnocchiclient/v1/resource_cli.py
+++ b/gnocchiclient/v1/resource_cli.py
@@ -11,8 +11,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import distutils.util
-
 from cliff import command
 from cliff import lister
 from cliff import show
@@ -174,7 +172,7 @@ class CliResourceCreate(show.ShowOne):
                 if attr_type == "number":
                     value = float(value)
                 elif attr_type == "bool":
-                    value = bool(distutils.util.strtobool(value))
+                    value = bool(utils.strtobool(value))
                 resource[attr] = value
         if (parsed_args.add_metric or
            parsed_args.create_metric or

--- a/gnocchiclient/v1/resource_type_cli.py
+++ b/gnocchiclient/v1/resource_type_cli.py
@@ -11,8 +11,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import distutils.util
-
 from cliff import command
 from cliff import lister
 from cliff import show
@@ -60,7 +58,7 @@ class CliResourceTypeCreate(show.ShowOne):
         if config:
             attrs["type"] = config.pop(0)
         if config:
-            attrs["required"] = bool(distutils.util.strtobool(config.pop(0)))
+            attrs["required"] = bool(utils.strtobool(config.pop(0)))
         while config:
             param, _, value = config.pop(0).partition("=")
             opts = attrs


### PR DESCRIPTION
Python 3.12 stopped shipping distutils:
https://docs.python.org/3/whatsnew/3.12.html
There're couple of places where gnocchiclient explicitly imports from distutils - which now does not work.

Luckily, those imports were for a single reson only - a strtobool function...
Let's just copy it over to utils.py and live with it, not that much of a burden to support own copy.