### PR TITLE
Add Python 3.10 and 3.12 support

### DIFF
--- a/gnocchiclient/utils.py
+++ b/gnocchiclient/utils.py
@@ -164,3 +164,25 @@ def parse_date(s):
 
 def dt_to_localtz(d):
     return d.astimezone(LOCAL_TIMEZONE)
+
+
+def str_to_bool(val):
+    """Convert a string representation of truth to ``True`` or ``False``.
+
+    ``True`` values are ``y``, ``yes``, ``t``, ``true``, ``on``, and ``1``.
+    ``False`` values are ``n``, ``no``, ``f``, ``false``, ``off``, and ``0``.
+
+    :param val: Value to convert to a boolean.
+    :type val: str
+    :raises ValueError: If ``val`` is anything other than the allowed values.
+    :return: ``True`` if the value is a truthy value, otherwise ``False``.
+    :rtype: bool
+    """
+    val = str(val).lower()
+
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        raise ValueError(f"Invalid truth value {val!r}")

--- a/gnocchiclient/v1/resource_cli.py
+++ b/gnocchiclient/v1/resource_cli.py
@@ -11,8 +11,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import distutils.util
-
 from cliff import command
 from cliff import lister
 from cliff import show
@@ -174,7 +172,7 @@ class CliResourceCreate(show.ShowOne):
                 if attr_type == "number":
                     value = float(value)
                 elif attr_type == "bool":
-                    value = bool(distutils.util.strtobool(value))
+                    value = utils.str_to_bool(value)
                 resource[attr] = value
         if (parsed_args.add_metric or
            parsed_args.create_metric or

--- a/gnocchiclient/v1/resource_type_cli.py
+++ b/gnocchiclient/v1/resource_type_cli.py
@@ -11,8 +11,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import distutils.util
-
 from cliff import command
 from cliff import lister
 from cliff import show
@@ -60,7 +58,7 @@ class CliResourceTypeCreate(show.ShowOne):
         if config:
             attrs["type"] = config.pop(0)
         if config:
-            attrs["required"] = bool(distutils.util.strtobool(config.pop(0)))
+            attrs["required"] = utils.str_to_bool(config.pop(0))
         while config:
             param, _, value = config.pop(0).partition("=")
             opts = attrs

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,9 @@ classifier =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 
 [options]
 packages =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.1
-envlist = py38,py39,py311,pep8,docs-gnocchi-web
+envlist = py38,py39,py310,py311,py312,pep8,docs-gnocchi-web
 skipsdist = True
 
 [testenv]
@@ -48,7 +48,7 @@ commands =
 
 [flake8]
 show-source = True
-ignore = D100,D101,D102,D103,D104,D105,D107,A002,A003,W504
+ignore = D100,D101,D102,D103,D104,D105,D107,A002,A003,A005,W504
 exclude=.git,.tox,dist,doc,*egg,build
 enable-extensions=G
 application-import-names = gnocchiclient


### PR DESCRIPTION
Fix python-gnocchiclient on Python 3.12 by replacing usage of distutils.util.strtobool with a new function in gnocchiclient.utils that does the same thing (except returns an actual boolean instead of an integer).

Added Python 3.12 to the package Trove classifiers and tox.ini.

Also added Python 3.10 to the package Trove classifiers and tox.ini, because it is generally an anti-pattern for a package to advertise Python 3.8-3.9 and Python 3.11+ support without also supporting Python 3.10.

Fix pep8 checks by suppressing the new A005 rule.