### PR TITLE
Get rid of pkg_resources

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -11,7 +11,7 @@
 # serve to show the default.
 
 import datetime
-import pkg_resources
+import importlib.metadata
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -51,7 +51,7 @@ copyright = u'%s, The Gnocchi Developers' % datetime.date.today().year
 # built documents.
 #
 # The short X.Y version.
-version = pkg_resources.get_distribution('gnocchiclient').version
+version = importlib.metadata.version('gnocchiclient')
 
 # The full version, including alpha/beta/rc tags.
 release = version

--- a/gnocchiclient/version.py
+++ b/gnocchiclient/version.py
@@ -12,11 +12,11 @@
 #    under the License.
 #
 
-import pkg_resources
+import importlib.metadata
 
 
 try:
-    __version__ = pkg_resources.get_distribution('gnocchiclient').version
-except pkg_resources.DistributionNotFound:
+    __version__ = importlib.metadata.version('gnocchiclient')
+except importlib.metadata.PackageNotFoundError:
     # package is not installed
     pass


### PR DESCRIPTION
... because it was removed in Python 3.12 [1].

[1] https://docs.python.org/3/whatsnew/3.12.html#ensurepip