### PR TITLE
Add Python 3.12 tests

### DIFF
--- a/.github/workflows/python-gnocchiclient.yml
+++ b/.github/workflows/python-gnocchiclient.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Install dependencies
         run: ./tools/install_deps.sh
       - name: Run tox
-        run: tox -e ${{ matrix.env }}
+        run: /tmp/gnocchi-tox-env/bin/tox -e ${{ matrix.env }}

--- a/.github/workflows/python-gnocchiclient.yml
+++ b/.github/workflows/python-gnocchiclient.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       matrix:
@@ -16,6 +16,7 @@ jobs:
           - pep8
           - py39
           - py311
+          - py312
     steps:
       - uses: actions/checkout@v4
         with:

--- a/tools/install_deps.sh
+++ b/tools/install_deps.sh
@@ -14,7 +14,9 @@ sudo apt-get update -y && sudo apt-get install -qy \
         python3.9-dev \
         python3.9-distutils \
         python3.11 \
-        python3.11-dev
+        python3.11-dev \
+        python3.12 \
+        python3.12-dev
 
 sudo rm -rf /var/lib/apt/lists/*
 

--- a/tools/install_deps.sh
+++ b/tools/install_deps.sh
@@ -24,4 +24,5 @@ export LANG=en_US.UTF-8
 sudo update-locale
 sudo locale-gen $LANG
 
-sudo python3 -m pip install -U pip tox virtualenv
+sudo python3 -m venv /tmp/gnocchi-tox-env
+sudo /tmp/gnocchi-tox-env/bin/python3 -m pip install -U pip tox virtualenv


### PR DESCRIPTION
... because now its support is declared. Note that distutils is no longer required since 24818b0c4e2fcb1be3f8cfb7ab52d59e8749d109 was merged.