### PR TITLE
Remove Python 3.8 support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ description_file =
 long_description_content_type = text/x-rst
 author = Gnocchi
 home_page = http://gnocchi.osci.io/gnocchiclient
-python_requires = >=3.8
+python_requires = >=3.9
 classifier =
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators
@@ -15,7 +15,6 @@ classifier =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11


### PR DESCRIPTION
Python 3.8 already reached its EOL.