### PR TITLE
Create dedicated exception for aggregation method not found

### DIFF
--- a/gnocchiclient/exceptions.py
+++ b/gnocchiclient/exceptions.py
@@ -120,6 +120,11 @@ class ArchivePolicyRuleNotFound(NotFound):
     match = re.compile("Archive policy rule .* does not exist")
 
 
+class AggregationMethodNotFound(NotFound):
+    message = "Aggregation method not found"
+    match = re.compile("Aggregation method does not exist for this metric")
+
+
 class MethodNotAllowed(ClientException):
     """HTTP 405 - Method Not Allowed."""
 


### PR DESCRIPTION
... so that we can detect 404 caused by missing aggregation method, instead of missing metric.